### PR TITLE
Refactor useState to useReducer for filter

### DIFF
--- a/src/components/Filter/index.tsx
+++ b/src/components/Filter/index.tsx
@@ -1,49 +1,42 @@
-import React from "react";
+import React, { Dispatch } from "react";
+import { ActionType, FilterAction, FilterRange, ValueFilters } from "../../App";
 
 type FilterProps = {
-  weightFilter: [number, number];
-  setWeightFilter: (value: [number, number]) => void;
+  filterState: ValueFilters;
+  dispatch: Dispatch<ActionType>;
 };
-const Filter: React.FC<FilterProps> = ({ weightFilter, setWeightFilter }) => {
-  //maybe use react hook - reducer?
-  const handleSetWeightFilterMin = (value: number) =>
-    setWeightFilter([value, weightFilter[1]]);
-  const handleSetWeightFilterMax = (value: number) =>
-    setWeightFilter([weightFilter[0], value]);
-
-  return (
-    <div>
-      <p>Filter</p>
-      <input
-        type="number"
-        name="min"
-        id="weight-min"
-        min="0"
-        max="9999"
-        value={weightFilter[0] || 0}
-        onChange={({ target: { value } }) => {
-          if (!value) {
-            handleSetWeightFilterMin(undefined);
-          }
-          handleSetWeightFilterMin(parseInt(value));
-        }}
-      />
-      <input
-        type="number"
-        name="max"
-        id="weight-max"
-        min="0"
-        max="9999"
-        value={weightFilter[1] ?? 0}
-        onChange={({ target: { value } }) => {
-          if (!value) {
-            handleSetWeightFilterMax(undefined);
-          }
-          handleSetWeightFilterMax(parseInt(value));
-        }}
-      />
-    </div>
-  );
-};
+const Filter: React.FC<FilterProps> = ({ filterState, dispatch }) => (
+  <div>
+    <p>Filter</p>
+    <input
+      type="number"
+      name="min"
+      id="weight-min"
+      min="0"
+      max="9999"
+      value={filterState.weight[0]}
+      onChange={({ target: { value } }) => {
+        dispatch({
+          type: FilterAction.SetMinWeight,
+          payload: parseInt(value),
+        });
+      }}
+    />
+    <input
+      type="number"
+      name="max"
+      id="weight-max"
+      min="0"
+      max="9999"
+      value={filterState.weight[1]}
+      onChange={({ target: { value } }) => {
+        dispatch({
+          type: FilterAction.SetMaxWeight,
+          payload: parseInt(value),
+        });
+      }}
+    />
+  </div>
+);
 
 export default Filter;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Pokemon } from "./App";
+import { FilterRange, Pokemon } from "./App";
 
 //allow currying so we can use the output directly into the next function
 const filterBySearchTerm = (pokemons: Pokemon[], searchTerm: string) =>
@@ -6,7 +6,7 @@ const filterBySearchTerm = (pokemons: Pokemon[], searchTerm: string) =>
     return pokemon.name.includes(searchTerm);
   });
 
-const filterByWeight = (pokemons: Pokemon[], weightFilter: [number, number]) =>
+const filterByWeight = (pokemons: Pokemon[], weightFilter: FilterRange) =>
   pokemons.filter(
     (pokemon) =>
       pokemon.weight >= weightFilter[0] && pokemon.weight <= weightFilter[1]
@@ -15,7 +15,7 @@ const filterByWeight = (pokemons: Pokemon[], weightFilter: [number, number]) =>
 export const filterPokemon = (
   pokemons: Pokemon[],
   searchTerm: string,
-  weightFilter: [number, number]
+  weightFilter: FilterRange
 ): Pokemon[] => {
   pokemons = filterBySearchTerm(pokemons, searchTerm);
   pokemons = filterByWeight(pokemons, weightFilter);


### PR DESCRIPTION
What?
Refactor to useReducer from useState for the value filters, currently only filter applied as weight. 

Why?
Currently, I only have the weight passed as a prop but soon I will be passing another 6 arguments. This allows me to pass through a single object that represents all filters, furthermore it will also simplify the need to have the get/set of each useState.

Future consideration?
I can already see the types and LOC getting out of hand in the App.tsx file and is likely to increase considerably with the addition of the future arguments/filter types. I think I should create a custom react hook to contain all of this.